### PR TITLE
Update logger to new HKMP API

### DIFF
--- a/Hkmp.ModDiff/Client.cs
+++ b/Hkmp.ModDiff/Client.cs
@@ -18,7 +18,7 @@ namespace Hkmp.ModDiff
         /// <inheritdoc />
         public override void Initialize(IClientApi clientApi)
         {
-            Logger.Info(this, "Client initialized");
+            Logger.Info("Client initialized");
 
             var mods = ModHooks.GetAllMods(true).Select(m => new ModVersion
             {
@@ -27,7 +27,7 @@ namespace Hkmp.ModDiff
             }).ToList();
             var dllDir = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             File.WriteAllText(Path.Combine(dllDir ?? string.Empty, "modlist.json"), JsonConvert.SerializeObject(mods, Formatting.Indented));
-            Logger.Info(this, "modlist.json created");
+            Logger.Info("modlist.json created");
 
             // ReSharper disable once ObjectCreationAsStatement
             new ClientNetService(Logger, this, clientApi);

--- a/Hkmp.ModDiff/Server.cs
+++ b/Hkmp.ModDiff/Server.cs
@@ -14,14 +14,14 @@ namespace Hkmp.ModDiff
         /// <inheritdoc />
         public override void Initialize(IServerApi serverApi)
         {
-            Logger.Info(this, "Server initialized");
+            Logger.Info("Server initialized");
 
             var dllDir = System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             var configPath = Path.Combine(dllDir ?? string.Empty, "moddiff_config.json");
             if (!File.Exists(configPath))
             {
                 File.WriteAllText(configPath, JsonConvert.SerializeObject(new Configuration(), Formatting.Indented));
-                Logger.Info(this, "Created configuration file");
+                Logger.Info("Created configuration file");
             }
 
             // ReSharper disable once ObjectCreationAsStatement

--- a/Hkmp.ModDiff/Services/ClientNetService.cs
+++ b/Hkmp.ModDiff/Services/ClientNetService.cs
@@ -4,6 +4,7 @@ using Hkmp.ModDiff.Extensions;
 using Hkmp.ModDiff.Models;
 using Hkmp.ModDiff.Packets;
 using Modding;
+using ILogger = Hkmp.Logging.ILogger;
 
 namespace Hkmp.ModDiff.Services
 {
@@ -14,7 +15,7 @@ namespace Hkmp.ModDiff.Services
             var sender = clientApi.NetClient.GetNetworkSender<ModListPacketId>(addon);
             clientApi.ClientManager.ConnectEvent += () =>
             {
-                logger.Info(this, "Player connected, sending modlist to server");
+                logger.Info("Player connected, sending modlist to server");
 
                 sender.SendSingleData(ModListPacketId.ModListClientData, new ModListPacket
                 {

--- a/Hkmp.ModDiff/Services/ServerNetService.cs
+++ b/Hkmp.ModDiff/Services/ServerNetService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Hkmp.Api.Server;
+using Hkmp.Logging;
 using Hkmp.ModDiff.Extensions;
 using Hkmp.ModDiff.Models;
 using Hkmp.ModDiff.Packets;
@@ -59,7 +60,7 @@ namespace Hkmp.ModDiff.Services
             if (attempts > maxAttempts)
             {
                 // We'll call this unreadable
-                _logger.Warn(this, $"Was unable to read locked file: {e.Name}");
+                _logger.Warn($"Was unable to read locked file: {e.Name}");
                 return;
             }
 
@@ -78,7 +79,7 @@ namespace Hkmp.ModDiff.Services
         {
             if (!File.Exists(Path.Combine(DllDirectory, ModlistFileName)))
             {
-                _logger.Warn(this, "No Modlist Provided.");
+                _logger.Warn("No Modlist Provided.");
                 return;
             }
 
@@ -89,14 +90,14 @@ namespace Hkmp.ModDiff.Services
             }
 
             _knownMods = JsonConvert.DeserializeObject<List<ModVersion>>(fileContents);
-            _logger.Info(this, "ModList Updated");
+            _logger.Info("ModList Updated");
         }
 
         private void HandleConfigChange()
         {
             if (!File.Exists(Path.Combine(DllDirectory, ConfigFileName)))
             {
-                _logger.Warn(this, "No Configuration Provided.");
+                _logger.Warn("No Configuration Provided.");
                 return;
             }
 
@@ -107,7 +108,7 @@ namespace Hkmp.ModDiff.Services
             }
 
             _configuration = JsonConvert.DeserializeObject<Configuration>(fileContents);
-            _logger.Info(this, "Configuration Updated");
+            _logger.Info("Configuration Updated");
         }
 
         private void HandleModlist(ushort id, ModListPacket data, IServerApi serverApi)
@@ -118,8 +119,7 @@ namespace Hkmp.ModDiff.Services
 
             var isMatch = CheckIsMatch(modInfo, _configuration.MismatchOnExtraMods);
 
-            _logger.Info(this,
-                !isMatch
+            _logger.Info(!isMatch
                     ? $"{data.PlayerInfo.PlayerName}'s mods DO NOT match!"
                     : $"{data.PlayerInfo.PlayerName} joined with matching mods!");
 
@@ -232,7 +232,7 @@ namespace Hkmp.ModDiff.Services
             }
             catch (Exception)
             {
-                _logger.Error(this, $"Unable to read text from file {path}. File is locked.");
+                _logger.Error($"Unable to read text from file {path}. File is locked.");
                 return null;
             }
         }


### PR DESCRIPTION
Due to changes in the HKMP API of the latest update to HKMP, the namespace of `ILogger` has changed as well as the signatures of the logging methods in it. This simple PR aims to update to accommodate for those changes.